### PR TITLE
tests: namespace moved to autoload-dev composer section

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,11 @@
   "license": "MIT",
   "autoload": {
     "psr-4": {
-      "LTS\\RussianValidators\\": "src/",
+      "LTS\\RussianValidators\\": "src/"
+    }
+  },
+  "autoload-dev": {
+    "psr-4": {
       "LTS\\RussianValidators\\Tests\\": "tests/"
     }
   },


### PR DESCRIPTION
Namespace тестов перемещён в секцию `autoload-dev` композера

## Чек-лист

- [x] Я **самостоятельно** проверил код моих изменений **перед** тем, как отдать его на code-review
- [x] Я подтянул `main`-ветку
- [x] Заголовок MR-а соответствует сути задачи и написан в формате [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
