### PR TITLE
fix: PHPDoc blocks for classes

### DIFF
--- a/src/AbstractValidator.php
+++ b/src/AbstractValidator.php
@@ -6,6 +6,9 @@ namespace LTS\RussianValidators;
 
 use InvalidArgumentException;
 
+/**
+ * Abstract class that can validate a value matches a pattern
+ */
 abstract class AbstractValidator implements ValidatorInterface
 {
     /**

--- a/src/ValidatorInterface.php
+++ b/src/ValidatorInterface.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace LTS\RussianValidators;
 
+/**
+ * Allows to validate that a value matches a rule
+ */
 interface ValidatorInterface
 {
     /**

--- a/tests/AbstractGeneralValidatorTest.php
+++ b/tests/AbstractGeneralValidatorTest.php
@@ -8,6 +8,9 @@ use LTS\RussianValidators\AbstractValidator;
 use PHPUnit\Framework\TestCase;
 use stdClass;
 
+/**
+ * Class that sets general invalid data sets
+ */
 abstract class AbstractGeneralValidatorTest extends TestCase
 {
     /**

--- a/tests/InnValidatorTest.php
+++ b/tests/InnValidatorTest.php
@@ -6,6 +6,9 @@ namespace LTS\RussianValidators\Tests;
 
 use LTS\RussianValidators\InnValidator;
 
+/**
+ * @coversDefaultClass \LTS\RussianValidators\InnValidator
+ */
 class InnValidatorTest extends AbstractGeneralValidatorTest
 {
     /**

--- a/tests/KppValidatorTest.php
+++ b/tests/KppValidatorTest.php
@@ -6,6 +6,9 @@ namespace LTS\RussianValidators\Tests;
 
 use LTS\RussianValidators\KppValidator;
 
+/**
+ * @coversDefaultClass \LTS\RussianValidators\KppValidator
+ */
 class KppValidatorTest extends AbstractGeneralValidatorTest
 {
     /**

--- a/tests/OgrnValidatorTest.php
+++ b/tests/OgrnValidatorTest.php
@@ -6,6 +6,9 @@ namespace LTS\RussianValidators\Tests;
 
 use LTS\RussianValidators\OgrnValidator;
 
+/**
+ * @coversDefaultClass \LTS\RussianValidators\OgrnValidator
+ */
 class OgrnValidatorTest extends AbstractGeneralValidatorTest
 {
     /**

--- a/tests/OgrnipValidatorTest.php
+++ b/tests/OgrnipValidatorTest.php
@@ -6,6 +6,9 @@ namespace LTS\RussianValidators\Tests;
 
 use LTS\RussianValidators\OgrnipValidator;
 
+/**
+ * @coversDefaultClass \LTS\RussianValidators\OgrnipValidator
+ */
 class OgrnipValidatorTest extends AbstractGeneralValidatorTest
 {
     /**

--- a/tests/SnilsValidatorTest.php
+++ b/tests/SnilsValidatorTest.php
@@ -6,6 +6,9 @@ namespace LTS\RussianValidators\Tests;
 
 use LTS\RussianValidators\SnilsValidator;
 
+/**
+ * @coversDefaultClass \LTS\RussianValidators\SnilsValidator
+ */
 class SnilsValidatorTest extends AbstractGeneralValidatorTest
 {
     /**


### PR DESCRIPTION
Добавлены PHPDoc-блоки для классов (включая `@coversDefaultClass` для тестов)

## Чек-лист

- [x] Я **самостоятельно** проверил код моих изменений **перед** тем, как отдать его на code-review
- [x] Я подтянул `main`-ветку
- [x] Заголовок MR-а соответствует сути задачи и написан в формате [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
